### PR TITLE
fix: pokemon item view holder background and clipped shadow

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -6,7 +6,7 @@
         <entry key="app/src/main/res/layout/activity_main.xml" value="0.2526041666666667" />
         <entry key="app/src/main/res/layout/content_main.xml" value="0.2526041666666667" />
         <entry key="app/src/main/res/layout/fragment_first.xml" value="0.2526041666666667" />
-        <entry key="app/src/main/res/layout/item_view_pokemon.xml" value="0.146875" />
+        <entry key="app/src/main/res/layout/item_view_pokemon.xml" value="0.1" />
       </map>
     </option>
   </component>

--- a/app/src/main/res/layout/item_view_pokemon.xml
+++ b/app/src/main/res/layout/item_view_pokemon.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
@@ -9,24 +10,27 @@
         android:layout_height="wrap_content"
         android:elevation="4dp"
         app:cardCornerRadius="8dp"
+        app:cardUseCompatPadding="true"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content">
+            android:layout_height="wrap_content"
+            android:background="@color/lavender_blue">
 
             <ImageView
                 android:id="@+id/image_thumbnail"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                android:background="@color/white"
+                android:layout_margin="16dp"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintDimensionRatio="w,1:1"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+                app:layout_constraintTop_toTopOf="parent"
+                tools:ignore="ContentDescription" />
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </androidx.cardview.widget.CardView>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,5 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="lavender_blue">#d4cdf4</color>
 </resources>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,4 +1,4 @@
 <resources>
     <dimen name="fab_margin">16dp</dimen>
-    <dimen name="spacing">16dp</dimen>
+    <dimen name="spacing">12dp</dimen>
 </resources>


### PR DESCRIPTION
Implement useCompatPadding and background color on Pokemon viewholder